### PR TITLE
Fixes to the configuration update

### DIFF
--- a/check_cd10_valid.py
+++ b/check_cd10_valid.py
@@ -18,6 +18,7 @@ from openlcb.pip import PIP
 import xmlschema
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -40,7 +41,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -64,12 +65,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -108,7 +109,7 @@ def check():
 
     # check for 0xFF space valid
     memory_address_space_cmd = [0x20, 0x84, 0xFF] 
-    datagram = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, memory_address_space_cmd)
+    datagram = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, memory_address_space_cmd)
     olcbchecker.sendMessage(datagram)
     try :
         content = getReplyDatagram(destination).data

--- a/check_cd20_read.py
+++ b/check_cd20_read.py
@@ -18,6 +18,7 @@ from openlcb.pip import PIP
 import xmlschema
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -40,7 +41,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -64,12 +65,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -119,7 +120,7 @@ def check():
         
         # send an read datagran
         request = [0x20, 0x43, ad1,ad2,ad3,ad4, LENGTH]
-        message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, request)
+        message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, request)
         olcbchecker.sendMessage(message)
 
         try :

--- a/check_cd30_acdi.py
+++ b/check_cd30_acdi.py
@@ -19,6 +19,7 @@ from openlcb.snip import SNIP
 import xmlschema
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -41,7 +42,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -65,12 +66,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -86,7 +87,7 @@ def read_memory(destination, address, length, space) :
     ad4 = address & 0xFF
 
     memory_read_command = [0x20, 0x40, ad1, ad2, ad3, ad4, space, length] 
-    datagram = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, memory_read_command)
+    datagram = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, memory_read_command)
     olcbchecker.sendMessage(datagram)
     content = getReplyDatagram(destination).data[7:]
     # if we just asked for one byte, return that as an int
@@ -142,7 +143,7 @@ def check():
     
         # check 251 and 252 spaces show present
         memory_address_space_cmd = [0x20, 0x84, 251] 
-        datagram = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, memory_address_space_cmd)
+        datagram = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, memory_address_space_cmd)
         olcbchecker.sendMessage(datagram)
         try :
             content = getReplyDatagram(destination).data
@@ -154,7 +155,7 @@ def check():
             return (3)
 
         memory_address_space_cmd = [0x20, 0x84, 252] 
-        datagram = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, memory_address_space_cmd)
+        datagram = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, memory_address_space_cmd)
         olcbchecker.sendMessage(datagram)
         try :
             content = getReplyDatagram(destination).data
@@ -191,7 +192,7 @@ def check():
     if snip_in_pip and acdi_in_pip and memory_config_present :
     
         # send an SNIP request message to provoke response
-        message = Message(MTI.Simple_Node_Ident_Info_Request, NodeID(olcbchecker.ownnodeid()), destination)
+        message = Message(MTI.Simple_Node_Ident_Info_Request, NodeID(configure.global_config.ownnodeid), destination)
         olcbchecker.sendMessage(message)
 
         results = []
@@ -205,7 +206,7 @@ def check():
                     print ("Failure - Unexpected source of reply message: {} {}".format(received, received.source))
                     return(3)
         
-                if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+                if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                     print ("Failure - Unexpected destination of reply message: {} {}".format(received, received.destination))
                     return(3)
         
@@ -260,7 +261,7 @@ def check():
         
             # send an read datagran
             request = [0x20, 0x43, ad1,ad2,ad3,ad4, LENGTH]
-            message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, request)
+            message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, request)
             olcbchecker.sendMessage(message)
 
             try :

--- a/check_da30_dr.py
+++ b/check_da30_dr.py
@@ -16,6 +16,7 @@ from openlcb.mti import MTI
 from openlcb.pip import PIP
 
 from queue import Empty
+import configure
 
 def check():
     # set up the infrastructure
@@ -51,7 +52,7 @@ def check():
         data = list(range(0, length))
 
         # send an datagram to provoke response
-        message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, data)
+        message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, data)
         olcbchecker.sendMessage(message)
 
         while True :
@@ -65,7 +66,7 @@ def check():
                     print ("Failure - Unexpected source of reply message: {} {}".format(received, received.source))
                     return(3)
         
-                if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+                if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                     print ("Failure - Unexpected destination of reply message: {} {}".format(received, received.destination))
                     return(3)
         

--- a/check_ev20_idg.py
+++ b/check_ev20_idg.py
@@ -91,7 +91,7 @@ def check():
         return(3)
         
     # now check if addressed gets the same as global. First, get addressed.
-    message = Message(MTI.Identify_Events_Addressed , NodeID(olcbchecker.ownnodeid()), destination)
+    message = Message(MTI.Identify_Events_Addressed , NodeID(configure.global_config.ownnodeid), destination)
     olcbchecker.sendMessage(message)
     
     producerSeen = set(())

--- a/check_ev30_ip.py
+++ b/check_ev30_ip.py
@@ -76,7 +76,7 @@ def check():
     # have the set to check, proceed to check each one
     fail = False
     for event in producedEvents :
-        message = Message(MTI.Identify_Producer, NodeID(olcbchecker.ownnodeid()), None, event.toArray())
+        message = Message(MTI.Identify_Producer, NodeID(configure.global_config.ownnodeid), None, event.toArray())
         olcbchecker.sendMessage(message)
 
         try:

--- a/check_ev40_ic.py
+++ b/check_ev40_ic.py
@@ -75,7 +75,7 @@ def check():
     # have the set to check, proceed to check each one
     fail = False
     for event in consumedEvents :
-        message = Message(MTI.Identify_Consumer, NodeID(olcbchecker.ownnodeid()), None, event.toArray())
+        message = Message(MTI.Identify_Consumer, NodeID(configure.global_config.ownnodeid), None, event.toArray())
         olcbchecker.sendMessage(message)
 
         try:

--- a/check_mc10_co.py
+++ b/check_mc10_co.py
@@ -16,6 +16,7 @@ from openlcb.mti import MTI
 from openlcb.pip import PIP
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -38,7 +39,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -62,12 +63,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -105,7 +106,7 @@ def check():
             return(0)
 
     # send an datagram to provoke response
-    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, [0x20, 0x80])
+    message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, [0x20, 0x80])
     olcbchecker.sendMessage(message)
 
     try :

--- a/check_mc20_ckasi.py
+++ b/check_mc20_ckasi.py
@@ -16,6 +16,7 @@ from openlcb.mti import MTI
 from openlcb.pip import PIP
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -38,7 +39,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -62,12 +63,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -109,7 +110,7 @@ def check():
     for space in spaces: 
 
         # send a "Get Address Space Information Command" datagram to provoke response
-        message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, [0x20, 0x84, space])
+        message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, [0x20, 0x84, space])
         olcbchecker.sendMessage(message)
 
         try :

--- a/check_mc30_read.py
+++ b/check_mc30_read.py
@@ -16,6 +16,7 @@ from openlcb.mti import MTI
 from openlcb.pip import PIP
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -38,7 +39,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -67,12 +68,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -84,7 +85,7 @@ def getReplyDatagram(destination) :
 def sendAndCheckResponse(destination, request, length) :
         # returns non-zero if fail
         # send a read datagram
-        message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, request)
+        message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, request)
         olcbchecker.sendMessage(message)
 
         try :

--- a/check_mc40_lock.py
+++ b/check_mc40_lock.py
@@ -16,6 +16,7 @@ from openlcb.mti import MTI
 from openlcb.pip import PIP
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -38,7 +39,7 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
     
             if received.mti == MTI.Datagram_Received_OK :
@@ -62,12 +63,12 @@ def getReplyDatagram(destination) :
             if destination != received.source : # check source in message header
                 continue
     
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 continue
 
             # here we've received the reply datagram
             # send the reply
-            message = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination, [0])
+            message = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination, [0])
             olcbchecker.sendMessage(message)
 
             return received
@@ -78,7 +79,7 @@ def getReplyDatagram(destination) :
 def sendLockCommand(destination, node) :
     reply = [0x20, 0x88]
     reply.extend(node)
-    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, reply)
+    message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, reply)
 
     olcbchecker.sendMessage(message)
 

--- a/check_mc50_restart.py
+++ b/check_mc50_restart.py
@@ -16,6 +16,7 @@ from openlcb.mti import MTI
 from openlcb.pip import PIP
 
 from queue import Empty
+import configure
 
 import olcbchecker.setup
 
@@ -47,7 +48,7 @@ def check():
             return(0)
 
     # send an datagram to restart the node
-    message = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, [0x20, 0xA9])
+    message = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, [0x20, 0xA9])
     olcbchecker.sendMessage(message)
 
     while True :

--- a/check_me20_verify.py
+++ b/check_me20_verify.py
@@ -78,7 +78,7 @@ def check():
     olcbchecker.purgeMessages()
 
     # send an addressed verify to this node and check for answer
-    message = Message(MTI.Verify_NodeID_Number_Addressed, NodeID(olcbchecker.ownnodeid()), destination)
+    message = Message(MTI.Verify_NodeID_Number_Addressed, NodeID(configure.global_config.ownnodeid), destination)
     olcbchecker.sendMessage(message)
 
     while True :
@@ -117,7 +117,7 @@ def check():
     olcbchecker.purgeMessages()
 
     # send an addressed verify to a different node (the origin node) and check for lack of answer
-    message = Message(MTI.Verify_NodeID_Number_Addressed, NodeID(olcbchecker.ownnodeid()), NodeID(olcbchecker.ownnodeid()))
+    message = Message(MTI.Verify_NodeID_Number_Addressed, NodeID(configure.global_config.ownnodeid), NodeID(configure.global_config.ownnodeid))
     olcbchecker.sendMessage(message)
 
     try :

--- a/check_me40_oir.py
+++ b/check_me40_oir.py
@@ -74,7 +74,7 @@ def check() :
                 print ("Failure - Unexpected source of reply message: {} {}".format(received, received.source))
                 return(3)
         
-            if NodeID(olcbchecker.ownnodeid()) != received.destination : # check destination in message header
+            if NodeID(configure.global_config.ownnodeid) != received.destination : # check destination in message header
                 print ("Failure - Unexpected destination of reply message: {} {}".format(received, received.destination))
                 return(3)
             if len(received.data) < 4:

--- a/check_me50_dup.py
+++ b/check_me50_dup.py
@@ -38,7 +38,7 @@ def check() :
         return 0  
     
     # send a message with our alias but target's NodeID to see if it provokes a response
-    message = Message(MTI.Verified_NodeID, NodeID(olcbchecker.ownnodeid()), None, destination.toArray()) # send from destination node
+    message = Message(MTI.Verified_NodeID, NodeID(configure.global_config.ownnodeid), None, destination.toArray()) # send from destination node
     olcbchecker.sendMessage(message)
 
     while True :

--- a/configure.py
+++ b/configure.py
@@ -41,6 +41,10 @@ class TestConfiguration:
     def trace(self):
         return self._trace
 
+    @trace.setter
+    def trace(self, value):
+        self._trace = value
+
     @property
     def devicename(self):
         return self._devicename
@@ -53,13 +57,25 @@ class TestConfiguration:
     def portnumber(self):
         return self._portnumber
 
+    @portnumber.setter
+    def portnumber(self, value):
+        self._portnumber = value
+
     @property
     def ownnodeid(self):
         return self._ownnodeid
 
+    @ownnodeid.setter
+    def ownnodeid(self, value):
+        self._ownnodeid = value
+
     @property
     def targetnodeid(self):
         return self._targetnodeid
+
+    @targetnodeid.setter
+    def targetnodeid(self, value):
+        self._targetnodeid = value
 
     @property
     def skip_interactive(self):
@@ -72,6 +88,10 @@ class TestConfiguration:
     @property
     def checkpip(self):
         return self._checkpip
+
+    @checkpip.setter
+    def checkpip(self, value):
+        self._checkpip = value
 
     @property
     def tests(self):

--- a/signal_generator.py
+++ b/signal_generator.py
@@ -33,11 +33,11 @@ def check():
     destination = olcbchecker.getTargetID()
 
     # predefine some messages
-    snip = Message(MTI.Simple_Node_Ident_Info_Request, NodeID(olcbchecker.ownnodeid()), destination)
-    pip = Message(MTI.Protocol_Support_Inquiry, NodeID(olcbchecker.ownnodeid()), destination)
-    datagramNull = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, [00, 00])
-    datagramRead = Message(MTI.Datagram, NodeID(olcbchecker.ownnodeid()), destination, [0x20, 0x43, 0, 0, 0, 0, 2])
-    datagramAck  = Message(MTI.Datagram_Received_OK, NodeID(olcbchecker.ownnodeid()), destination)
+    snip = Message(MTI.Simple_Node_Ident_Info_Request, NodeID(configure.global_config.ownnodeid), destination)
+    pip = Message(MTI.Protocol_Support_Inquiry, NodeID(configure.global_config.ownnodeid), destination)
+    datagramNull = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, [00, 00])
+    datagramRead = Message(MTI.Datagram, NodeID(configure.global_config.ownnodeid), destination, [0x20, 0x43, 0, 0, 0, 0, 2])
+    datagramAck  = Message(MTI.Datagram_Received_OK, NodeID(configure.global_config.ownnodeid), destination)
     
     # wait for alias allocation to complete
     time.sleep(2.000)


### PR DESCRIPTION
I'm having trouble getting this to run completely

I've added setter's for trace, portnumber, ownnodeid, targetnodeid and checkpip. I replaced `olcbchecker.ownnodeid()` with `configure.global_config.ownnodeid` in a lot of files to fix the old-style references.

Could you merge this PR please?  Then we'll be working on the same updates.

There are still some issues that I'd like help with.

1) When I try to run via a network connection to a CS-105, I get an error:

```
% ./control_master.py --hostname 192.168.16.212 --port 12021 --run-all
Traceback (most recent call last):
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/./control_master.py", line 243, in <module>
    main()
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/./control_master.py", line 159, in main
    tests_to_run = all_tests()
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/./control_master.py", line 69, in all_tests
    import control_frame
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/control_frame.py", line 7, in <module>
    import check_fr10_init
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/check_fr10_init.py", line 17, in <module>
    import olcbchecker.setup
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/olcbchecker/setup.py", line 29, in <module>
    s.connect(configure.global_config.hostname, configure.global_config.portnumber)
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/openlcb/canbus/tcpsocket.py", line 27, in connect
    self.sock.connect((host, port))
TypeError: 'str' object cannot be interpreted as an integer

```

Where's the right place to fix this?  Happy to do it, but I don't yet understand how the various parts of the configuration fit together.

2) Running with a LocoBuffer was sort-of working. I can get it to run through on some hardware with `--run-all` set.

But I can't figure out how to get to the main menu.  E.g. this 

```
./control_master.py --device /dev/cu.usbmodemCC57000CF1 --skip-interactive --run-all
```

runs the tests OK, but I don't know how to get to the menu that lets me select specific tests. Could you give me the proper command and arguments for that? Thanks.

3) Also, I don't seem to be able to run individual test files.  I would have thought that

```
./control_message.py --device /dev/cu.usbmodemCC57000CF1
```

would work. It gets me to the message-test menu. But when I try to run the verify tests, I get
```
Traceback (most recent call last):
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/./control_message.py", line 82, in <module>
    main()
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/./control_message.py", line 62, in main
    check_me20_verify.check()
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/check_me20_verify.py", line 24, in check
    import olcbchecker.setup
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/olcbchecker/setup.py", line 33, in <module>
    s.connect(configure.global_config.devicename)
  File "/Users/jake/Documents/Trains/JMRI/projects/openlcb/OlcbChecker/openlcb/canbus/seriallink.py", line 25, in connect
    self.port.reset_input_buffer()  # drop anything that's just sitting there already  # noqa: E501
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/serial/serialposix.py", line 682, in reset_input_buffer
    raise PortNotOpenError()
serial.serialutil.PortNotOpenError: Attempting to use a port that is not open
```

I get a similar error when I try to run the one Verify test directly:

```
./check_me20_verify.py --device /dev/cu.usbmodemCC57000CF1 
```

Thanks for looking at these things.


